### PR TITLE
Fix initialization order

### DIFF
--- a/extension/src/main/scala/io/scalac/mesmer/extension/AkkaMonitoring.scala
+++ b/extension/src/main/scala/io/scalac/mesmer/extension/AkkaMonitoring.scala
@@ -115,7 +115,7 @@ final class AkkaMonitoring(private val system: ActorSystem[_], val config: AkkaM
   import AkkaMonitoring.ExportInterval
   import system.log
 
-  private val meter                              = InstrumentationLibrary.meter
+  private val meter                              = InstrumentationLibrary.mesmerMeter
   private val actorSystemConfig                  = system.settings.config
   private val openTelemetryClusterMetricsMonitor = OpenTelemetryClusterMetricsMonitor(meter, actorSystemConfig)
   import io.scalac.mesmer.core.AkkaDispatcher._

--- a/extension/src/main/scala/io/scalac/mesmer/extension/config/InstrumentationLibrary.scala
+++ b/extension/src/main/scala/io/scalac/mesmer/extension/config/InstrumentationLibrary.scala
@@ -8,7 +8,7 @@ object InstrumentationLibrary {
 
   private final val name = "mesmer-akka"
 
-  val meterProvider: MeterProvider = GlobalMeterProvider.get()
-  val meter: Meter                 = meterProvider.get(name)
+  def meterProvider: MeterProvider = GlobalMeterProvider.get()
+  def mesmerMeter: Meter           = meterProvider.get(name)
 
 }


### PR DESCRIPTION
Mesmer extension was initialized before sdk metric producer which defaulted to noop metric producer to be used for all monitors.