### PR TITLE
Death watch stream

### DIFF
--- a/agent/src/main/scala/io/scalac/mesmer/agent/util/i13n/InstrumentModuleFactory.scala
+++ b/agent/src/main/scala/io/scalac/mesmer/agent/util/i13n/InstrumentModuleFactory.scala
@@ -6,4 +6,5 @@ trait InstrumentModuleFactory {
   protected def supportedModules: SupportedModules
 
   protected def instrument(tpe: Type): TypeInstrumentation = TypeInstrumentation(TypeTarget(tpe, supportedModules))
+
 }

--- a/core/src/main/scala/io/scalac/mesmer/core/akka/model/package.scala
+++ b/core/src/main/scala/io/scalac/mesmer/core/akka/model/package.scala
@@ -6,4 +6,5 @@ package object model {
    * Command signalling that actor should send accumulated metrics in reply
    */
   private[scalac] case object PushMetrics
+
 }

--- a/core/src/main/scala/io/scalac/mesmer/core/akka/package.scala
+++ b/core/src/main/scala/io/scalac/mesmer/core/akka/package.scala
@@ -1,0 +1,23 @@
+package io.scalac.mesmer.core
+
+import io.scalac.mesmer.core.model.ActorPath
+
+import scala.math.PartialOrdering
+
+package object akka {
+
+  implicit val actorPathPartialOrdering: PartialOrdering[ActorPath] = new PartialOrdering[ActorPath] {
+    def tryCompare(x: ActorPath, y: ActorPath): Option[Int] =
+      (x, y) match {
+        case (xPath, yPath) if xPath == yPath          => Some(0)
+        case (xPath, yPath) if xPath.startsWith(yPath) => Some(1)
+        case (xPath, yPath) if yPath.startsWith(xPath) => Some(-1)
+        case _                                         => None
+      }
+
+    def lteq(x: ActorPath, y: ActorPath): Boolean = actorLevel(x) <= actorLevel(y)
+
+    private def actorLevel(path: ActorPath): Int = path.count(_ == '/')
+  }
+
+}

--- a/core/src/main/scala/io/scalac/mesmer/core/akka/package.scala
+++ b/core/src/main/scala/io/scalac/mesmer/core/akka/package.scala
@@ -1,8 +1,8 @@
 package io.scalac.mesmer.core
 
-import io.scalac.mesmer.core.model.ActorPath
-
 import scala.math.PartialOrdering
+
+import io.scalac.mesmer.core.model.ActorPath
 
 package object akka {
 

--- a/core/src/main/scala/io/scalac/mesmer/core/model/ActorRefDetails.scala
+++ b/core/src/main/scala/io/scalac/mesmer/core/model/ActorRefDetails.scala
@@ -11,4 +11,6 @@ private[scalac] final case class ActorRefDetails(
   ref: classic.ActorRef,
   tags: Set[Tag],
   configuration: ActorConfiguration
-)
+) {
+  def withTag(tag: Tag): ActorRefDetails = copy(tags = tags + tag)
+}

--- a/core/src/main/scala/io/scalac/mesmer/core/model/Tag.scala
+++ b/core/src/main/scala/io/scalac/mesmer/core/model/Tag.scala
@@ -12,8 +12,9 @@ sealed trait Tag extends Any {
 }
 
 object Tag {
-  val stream: Tag = StreamTag
-  val all: Tag    = All
+  val stream: Tag     = StreamTag
+  val terminated: Tag = TerminatedTag
+  val all: Tag        = All
 
   private case object All extends Tag {
     override def serialize: Seq[(String, String)] = Seq.empty
@@ -21,6 +22,10 @@ object Tag {
 
   private case object StreamTag extends Tag {
     lazy val serialize: Seq[(String, String)] = Seq(("stream", "true"))
+  }
+
+  private case object TerminatedTag extends Tag {
+    lazy val serialize: Seq[(String, String)] = Seq.empty
   }
 
   sealed trait StageName extends Any with Tag {

--- a/core/src/main/scala/io/scalac/mesmer/core/util/AggMetric.scala
+++ b/core/src/main/scala/io/scalac/mesmer/core/util/AggMetric.scala
@@ -30,9 +30,10 @@ object AggMetric {
       val count = this.count + other.count
       val sum   = this.sum + other.sum
       val avg   = if (count == 0) 0L else Math.floorDiv(sum, count)
+
       LongValueAggMetric(
         min = if (this.min < other.min) this.min else other.min,
-        max = if (this.max > other.min) this.max else other.max,
+        max = if (this.max > other.max) this.max else other.max,
         avg = avg,
         sum = sum,
         count = count

--- a/core/src/test/scala/io/scalac/mesmer/core/util/probe/ObserverCollector.scala
+++ b/core/src/test/scala/io/scalac/mesmer/core/util/probe/ObserverCollector.scala
@@ -50,11 +50,11 @@ object ObserverCollector {
     start()
   }
 
-  class ScheduledCollectorImpl(pingOffset: FiniteDuration)(implicit val system: ActorSystem[_])
+  final class ScheduledCollectorImpl(pingOffset: FiniteDuration)(implicit val system: ActorSystem[_])
       extends ScheduledCollector(pingOffset)
       with MapBasedObserverCollector
       with AutoStartCollector
 
-  class ManualCollectorImpl extends ObserverCollector with MapBasedObserverCollector
+  final class ManualCollectorImpl extends ObserverCollector with MapBasedObserverCollector
 
 }

--- a/extension/src/main/scala/io/scalac/mesmer/extension/ActorEventsMonitorActor.scala
+++ b/extension/src/main/scala/io/scalac/mesmer/extension/ActorEventsMonitorActor.scala
@@ -1,40 +1,26 @@
 package io.scalac.mesmer.extension
 
-import java.util.concurrent.atomic.AtomicReference
-
 import akka.actor.typed._
 import akka.actor.typed.receptionist.Receptionist.Listing
-import akka.actor.typed.scaladsl.ActorContext
-import akka.actor.typed.scaladsl.Behaviors
-import akka.actor.typed.scaladsl.TimerScheduler
+import akka.actor.typed.scaladsl.{ ActorContext, Behaviors, TimerScheduler }
 import akka.util.Timeout
 import akka.{ actor => classic }
-import org.slf4j.LoggerFactory
-
-import scala.concurrent.duration._
-import scala.util.Failure
-import scala.util.Success
-
-import io.scalac.mesmer.core.model.ActorKey
-import io.scalac.mesmer.core.model.ActorRefDetails
-import io.scalac.mesmer.core.model.Node
-import io.scalac.mesmer.core.util.ActorCellOps
-import io.scalac.mesmer.core.util.ActorPathOps
-import io.scalac.mesmer.core.util.ActorRefOps
+import io.scalac.mesmer.core.model.{ ActorKey, ActorRefDetails, Node }
+import io.scalac.mesmer.core.util.{ ActorCellOps, ActorPathOps, ActorRefOps }
 import io.scalac.mesmer.extension.ActorEventsMonitorActor._
-import io.scalac.mesmer.extension.actor.ActorCellDecorator
-import io.scalac.mesmer.extension.actor.ActorMetrics
-import io.scalac.mesmer.extension.actor.MetricStorageFactory
+import io.scalac.mesmer.extension.actor.{ ActorCellDecorator, ActorMetrics, MetricStorageFactory }
 import io.scalac.mesmer.extension.metric.ActorMetricsMonitor
 import io.scalac.mesmer.extension.metric.ActorMetricsMonitor.Labels
 import io.scalac.mesmer.extension.metric.MetricObserver.Result
-import io.scalac.mesmer.extension.service.ActorTreeService
 import io.scalac.mesmer.extension.service.ActorTreeService.Command.GetActorTree
-import io.scalac.mesmer.extension.service.actorTreeServiceKey
-import io.scalac.mesmer.extension.util.GenericBehaviors
-import io.scalac.mesmer.extension.util.Tree.Tree
-import io.scalac.mesmer.extension.util.Tree._
-import io.scalac.mesmer.extension.util.TreeF
+import io.scalac.mesmer.extension.service.{ actorTreeServiceKey, ActorTreeService }
+import io.scalac.mesmer.extension.util.Tree.{ Tree, _ }
+import io.scalac.mesmer.extension.util.{ GenericBehaviors, TreeF }
+import org.slf4j.LoggerFactory
+
+import java.util.concurrent.atomic.AtomicReference
+import scala.concurrent.duration._
+import scala.util.{ Failure, Success }
 
 object ActorEventsMonitorActor {
 

--- a/extension/src/main/scala/io/scalac/mesmer/extension/ActorEventsMonitorActor.scala
+++ b/extension/src/main/scala/io/scalac/mesmer/extension/ActorEventsMonitorActor.scala
@@ -1,28 +1,46 @@
 package io.scalac.mesmer.extension
 
+import java.util.concurrent.atomic.AtomicReference
+
+import akka.Done
 import akka.actor.typed._
 import akka.actor.typed.receptionist.Receptionist.Listing
-import akka.actor.typed.scaladsl.{ ActorContext, Behaviors, TimerScheduler }
+import akka.actor.typed.scaladsl.ActorContext
+import akka.actor.typed.scaladsl.Behaviors
+import akka.actor.typed.scaladsl.TimerScheduler
 import akka.util.Timeout
-import akka.{ Done, actor => classic }
+import akka.{ actor => classic }
+import org.slf4j.LoggerFactory
+
+import scala.concurrent.duration._
+import scala.util.Failure
+import scala.util.Success
+
 import io.scalac.mesmer.core.akka.actorPathPartialOrdering
-import io.scalac.mesmer.core.model.{ ActorKey, ActorRefDetails, Node, Tag }
-import io.scalac.mesmer.core.util.{ ActorCellOps, ActorPathOps, ActorRefOps }
+import io.scalac.mesmer.core.model.ActorKey
+import io.scalac.mesmer.core.model.ActorRefDetails
+import io.scalac.mesmer.core.model.Node
+import io.scalac.mesmer.core.model.Tag
+import io.scalac.mesmer.core.util.ActorCellOps
+import io.scalac.mesmer.core.util.ActorPathOps
+import io.scalac.mesmer.core.util.ActorRefOps
 import io.scalac.mesmer.extension.ActorEventsMonitorActor._
-import io.scalac.mesmer.extension.actor.{ ActorCellDecorator, ActorMetrics, MetricStorageFactory }
+import io.scalac.mesmer.extension.actor.ActorCellDecorator
+import io.scalac.mesmer.extension.actor.ActorMetrics
+import io.scalac.mesmer.extension.actor.MetricStorageFactory
 import io.scalac.mesmer.extension.metric.ActorMetricsMonitor
 import io.scalac.mesmer.extension.metric.ActorMetricsMonitor.Labels
 import io.scalac.mesmer.extension.metric.MetricObserver.Result
-import io.scalac.mesmer.extension.service.ActorTreeService.Command.{ GetActorTree, TagSubscribe }
-import io.scalac.mesmer.extension.service.{ actorTreeServiceKey, ActorTreeService }
+import io.scalac.mesmer.extension.service.ActorTreeService
+import io.scalac.mesmer.extension.service.ActorTreeService.Command.GetActorTree
+import io.scalac.mesmer.extension.service.ActorTreeService.Command.TagSubscribe
+import io.scalac.mesmer.extension.service.actorTreeServiceKey
+import io.scalac.mesmer.extension.util.GenericBehaviors
+import io.scalac.mesmer.extension.util.Tree
+import io.scalac.mesmer.extension.util.Tree.Tree
 import io.scalac.mesmer.extension.util.Tree.TreeOrdering._
-import io.scalac.mesmer.extension.util.Tree.{ Tree, _ }
-import io.scalac.mesmer.extension.util.{ GenericBehaviors, Tree, TreeF }
-import org.slf4j.LoggerFactory
-
-import java.util.concurrent.atomic.AtomicReference
-import scala.concurrent.duration._
-import scala.util.{ Failure, Success }
+import io.scalac.mesmer.extension.util.Tree._
+import io.scalac.mesmer.extension.util.TreeF
 
 object ActorEventsMonitorActor {
 

--- a/extension/src/main/scala/io/scalac/mesmer/extension/actor/ActorMetrics.scala
+++ b/extension/src/main/scala/io/scalac/mesmer/extension/actor/ActorMetrics.scala
@@ -31,18 +31,6 @@ final case class ActorMetrics(
     droppedMessages = combineLong(droppedMessages, other.droppedMessages)
   )
 
-  def sum(other: ActorMetrics): ActorMetrics = ActorMetrics(
-    mailboxSize = combineLong(mailboxSize, other.mailboxSize),
-    mailboxTime = sumAggregation(mailboxTime, other.mailboxTime),
-    receivedMessages = combineLong(receivedMessages, other.receivedMessages),
-    unhandledMessages = combineLong(unhandledMessages, other.unhandledMessages),
-    failedMessages = combineLong(failedMessages, other.failedMessages),
-    processingTime = sumAggregation(processingTime, other.processingTime),
-    sentMessages = combineLong(sentMessages, other.sentMessages),
-    stashSize = combineLong(stashSize, other.stashSize),
-    droppedMessages = combineLong(droppedMessages, other.droppedMessages)
-  )
-
   private def combineLong(first: Option[Long], second: Option[Long]): Option[Long] =
     combineOption(first, second)(_ + _)
 
@@ -50,11 +38,6 @@ final case class ActorMetrics(
     first: Option[LongValueAggMetric],
     second: Option[LongValueAggMetric]
   ): Option[LongValueAggMetric] = combineOption(first, second)(_.combine(_))
-
-  private def sumAggregation(
-    first: Option[LongValueAggMetric],
-    second: Option[LongValueAggMetric]
-  ): Option[LongValueAggMetric] = combineOption(first, second)(_.sum(_))
 
   private def combineOption[T](first: Option[T], second: Option[T])(combine: (T, T) => T): Option[T] =
     (first, second) match {

--- a/extension/src/main/scala/io/scalac/mesmer/extension/service/ActorTreeService.scala
+++ b/extension/src/main/scala/io/scalac/mesmer/extension/service/ActorTreeService.scala
@@ -2,21 +2,47 @@ package io.scalac.mesmer.extension.service
 
 import akka.actor.typed._
 import akka.actor.typed.receptionist.Receptionist.Register
-import akka.actor.typed.scaladsl.AbstractBehavior
-import akka.actor.typed.scaladsl.ActorContext
-import akka.actor.typed.scaladsl.Behaviors
 import akka.actor.typed.scaladsl.adapter._
-import akka.{ actor => classic }
-
+import akka.actor.typed.scaladsl.{AbstractBehavior, ActorContext, Behaviors}
+import akka.{actor => classic}
 import io.scalac.mesmer.core
 import io.scalac.mesmer.core.event.ActorEvent
-import io.scalac.mesmer.core.model.Tag
-import io.scalac.mesmer.core.model._
+import io.scalac.mesmer.core.model.{Tag, _}
 import io.scalac.mesmer.extension.metric.ActorSystemMonitor
 import io.scalac.mesmer.extension.metric.ActorSystemMonitor.Labels
 import io.scalac.mesmer.extension.service.ActorTreeService.Api
-import io.scalac.mesmer.extension.util.Tree.Tree
+import io.scalac.mesmer.extension.service.SubscriptionService.{AddSubscriber, Broadcast}
+import io.scalac.mesmer.extension.util.Tree.{Tree, TreeOrdering}
 import io.scalac.mesmer.extension.util._
+
+import scala.collection.mutable
+
+object SubscriptionService {
+  sealed trait Command[T]
+
+  final case class AddSubscriber[T](ref: ActorRef[T]) extends Command[T]
+
+  final case class Broadcast[T](value: T) extends Command[T]
+
+  def apply[T](): Behavior[Command[T]] = Behaviors.setup { ctx =>
+    def start(subscribers: Set[ActorRef[T]]): Behavior[Command[T]] = Behaviors
+      .receiveMessage[Command[T]] {
+        case AddSubscriber(ref) =>
+          if (!subscribers.contains(ref)) {
+            ctx.watch(ref)
+            start(subscribers + ref)
+          } else Behaviors.same
+        case Broadcast(value) =>
+          subscribers.foreach(_.tell(value))
+          Behaviors.same
+      }
+      .receiveSignal { case (_, Terminated(ref)) =>
+        start(subscribers - ref.unsafeUpcast[T])
+      }
+
+    start(Set.empty)
+  }
+}
 
 object ActorTreeService {
 
@@ -31,6 +57,8 @@ object ActorTreeService {
     final case class GetActors(tags: Tag, reply: ActorRef[Seq[classic.ActorRef]]) extends Command
 
     final case class GetActorTree(reply: ActorRef[Tree[ActorRefDetails]]) extends Command
+
+    final case class TagSubscribe(tag: Tag, reply: ActorRef[ActorRefDetails]) extends Command
 
   }
 
@@ -85,7 +113,7 @@ final class ActorTreeService(
   actorTreeTraverser: ActorTreeTraverser,
   actorConfigurationService: ActorConfigurationService,
   node: Option[Node] = None
-)(implicit actorRefPartialOrdering: PartialOrdering[classic.ActorRef])
+)(implicit actorRefTreeOrdering: TreeOrdering[classic.ActorRef])
     extends AbstractBehavior[Api](ctx) {
   import ActorTreeService._
   import Command._
@@ -96,10 +124,13 @@ final class ActorTreeService(
   private[this] val snapshot     = Tree.builder[classic.ActorRef, ActorRefDetails]
   private[this] val boundMonitor = monitor.bind(Labels(node))
 
+  private[this] lazy val subscriptions = mutable.Map
+    .empty[Tag, ActorRef[SubscriptionService.Command[ActorRefDetails]]]
+    .withDefault(_ => ctx.spawnAnonymous(SubscriptionService.apply[ActorRefDetails]()))
+
   private def toActorRefDetails(refWithTags: ActorRefTags): ActorRefDetails = {
     import refWithTags._
     ActorRefDetails(ref, tags, actorConfigurationService.forActorPath(ref.path))
-
   }
 
   private def init(): Unit = {
@@ -115,6 +146,11 @@ final class ActorTreeService(
       }
   }
 
+  private def notifySubscribers(details: ActorRefDetails): Unit =
+    details.tags.foreach { tag =>
+      subscriptions.get(tag).foreach(_ ! Broadcast(details))
+    }
+
   def onMessage(msg: Api): Behavior[Api] = msg match {
     case GetActors(Tag.all, reply) =>
       reply ! snapshot.buildSeq((ref, _) => Some(ref))
@@ -125,6 +161,9 @@ final class ActorTreeService(
     case GetActorTree(reply) =>
       //TODO change this to be more secure
       snapshot.buildTree((_, details) => Some(details)).foreach(reply ! _)
+      Behaviors.same
+    case TagSubscribe(tag, ref) =>
+      subscriptions(tag) ! AddSubscriber(ref)
       Behaviors.same
     case event: Event =>
       handleEvent(event)
@@ -150,16 +189,19 @@ final class ActorTreeService(
       context.watchWith(details.ref.toTyped, ActorTerminated(ref))
       boundMonitor.createdActors.incValue(1L)
       snapshot.insert(ref, details)
+      notifySubscribers(details)
 
     case ActorRetagged(details) =>
       import details._
       log.trace("Actor retagged {}", ref)
       snapshot.modify(ref, _ => details)
+      notifySubscribers(details)
 
     case ActorTerminated(ref) =>
       log.trace("Actor terminated {}", ref)
       boundMonitor.terminatedActors.incValue(1L)
-      snapshot.remove(ref)
+      val (removed, _) = snapshot.remove(ref)
+      removed.foreach(details => notifySubscribers(details.withTag(Tag.terminated)))
   }
 
   // bind to actor event stream

--- a/extension/src/main/scala/io/scalac/mesmer/extension/service/ActorTreeService.scala
+++ b/extension/src/main/scala/io/scalac/mesmer/extension/service/ActorTreeService.scala
@@ -2,21 +2,27 @@ package io.scalac.mesmer.extension.service
 
 import akka.actor.typed._
 import akka.actor.typed.receptionist.Receptionist.Register
+import akka.actor.typed.scaladsl.AbstractBehavior
+import akka.actor.typed.scaladsl.ActorContext
+import akka.actor.typed.scaladsl.Behaviors
 import akka.actor.typed.scaladsl.adapter._
-import akka.actor.typed.scaladsl.{ AbstractBehavior, ActorContext, Behaviors }
-import akka.{ actor, actor => classic }
-import io.scalac.mesmer.core
-import io.scalac.mesmer.core.event.ActorEvent
-import io.scalac.mesmer.core.model.{ Tag, _ }
-import io.scalac.mesmer.extension.metric.ActorSystemMonitor
-import io.scalac.mesmer.extension.metric.ActorSystemMonitor.Labels
-import io.scalac.mesmer.extension.service.ActorTreeService.Api
-import io.scalac.mesmer.extension.service.SubscriptionService.{ AddSubscriber, Broadcast }
-import io.scalac.mesmer.extension.util.Tree.{ Tree, TreeOrdering }
-import io.scalac.mesmer.extension.util._
+import akka.{ actor => classic }
 
 import scala.collection.mutable
 import scala.math.PartialOrdering
+
+import io.scalac.mesmer.core
+import io.scalac.mesmer.core.event.ActorEvent
+import io.scalac.mesmer.core.model.Tag
+import io.scalac.mesmer.core.model._
+import io.scalac.mesmer.extension.metric.ActorSystemMonitor
+import io.scalac.mesmer.extension.metric.ActorSystemMonitor.Labels
+import io.scalac.mesmer.extension.service.ActorTreeService.Api
+import io.scalac.mesmer.extension.service.SubscriptionService.AddSubscriber
+import io.scalac.mesmer.extension.service.SubscriptionService.Broadcast
+import io.scalac.mesmer.extension.util.Tree.Tree
+import io.scalac.mesmer.extension.util.Tree.TreeOrdering
+import io.scalac.mesmer.extension.util._
 
 object SubscriptionService {
   sealed trait Command[T]
@@ -123,12 +129,12 @@ final class ActorTreeService(
   import ActorTreeService._
   import context._
 
-  private[this] implicit val refPartialOrdering =
+  private[this] implicit val refPartialOrdering: TreeOrdering[classic.ActorRef] =
     TreeOrdering.fromPartialOrdering(new PartialOrdering[classic.ActorRef] {
-      def tryCompare(x: actor.ActorRef, y: actor.ActorRef): Option[Int] = core.akka.actorPathPartialOrdering
+      def tryCompare(x: classic.ActorRef, y: classic.ActorRef): Option[Int] = core.akka.actorPathPartialOrdering
         .tryCompare(x.path.toStringWithoutAddress, y.path.toStringWithoutAddress)
 
-      def lteq(x: actor.ActorRef, y: actor.ActorRef): Boolean = core.akka.actorPathPartialOrdering
+      def lteq(x: classic.ActorRef, y: classic.ActorRef): Boolean = core.akka.actorPathPartialOrdering
         .lteq(x.path.toStringWithoutAddress, y.path.toStringWithoutAddress)
     })
 

--- a/extension/src/main/scala/io/scalac/mesmer/extension/util/Tree.scala
+++ b/extension/src/main/scala/io/scalac/mesmer/extension/util/Tree.scala
@@ -43,6 +43,12 @@ object Tree {
 
   def builder[K, V](implicit ordering: TreeOrdering[K]): Builder[K, V] = new Root[K, V](None, ArrayBuffer.empty)
 
+  /**
+   * Builder is a mutable structure
+   * @param keyOrdering
+   * @tparam K
+   * @tparam V
+   */
   sealed abstract class Builder[K, V](implicit val keyOrdering: TreeOrdering[K]) {
 
     /**
@@ -98,6 +104,9 @@ object Tree {
      * @return new flat structure
      */
     def buildSeq[O](filter: (K, V) => Option[O]): Seq[O]
+
+
+
   }
 
   trait TreeOrdering[T] {
@@ -109,7 +118,7 @@ object Tree {
   }
 
   object TreeOrdering {
-    implicit def fromPartialOrdering[T](partialOrdering: PartialOrdering[T]): TreeOrdering[T] = new TreeOrdering[T] {
+    implicit def fromPartialOrdering[T](implicit partialOrdering: PartialOrdering[T]): TreeOrdering[T] = new TreeOrdering[T] {
       def isParent(x: T, y: T): Boolean                     = partialOrdering.tryCompare(x, y).exists(_ < 0)
       def isChild(x: T, y: T): Boolean                      = partialOrdering.tryCompare(x, y).exists(_ > 0)
       def isChildOrSame(x: T, y: T): Boolean                = partialOrdering.tryCompare(x, y).exists(_ >= 0)

--- a/extension/src/main/scala/io/scalac/mesmer/extension/util/Tree.scala
+++ b/extension/src/main/scala/io/scalac/mesmer/extension/util/Tree.scala
@@ -44,6 +44,10 @@ object Tree {
     def find(predicate: T => Boolean): Option[T] = foldRight[Option[T]] { case TreeF(value, children) =>
       children.flatten.headOption.orElse(Some(value).filter(predicate))
     }
+
+    def foreach(action: T => Unit): Unit = foldRight[Unit] { case TreeF(value, _) =>
+      action(value)
+    }
   }
 
   def leaf[T](value: T): Tree[T] = tree(value)

--- a/extension/src/test/scala/io/scalac/mesmer/extension/ActorEventsMonitorActorTest.scala
+++ b/extension/src/test/scala/io/scalac/mesmer/extension/ActorEventsMonitorActorTest.scala
@@ -135,7 +135,6 @@ final class ActorEventsMonitorActorTest
     monitor: ActorRef[Done]
   ): Tree[ActorRefDetails] => Behavior[ActorTreeService.Command] = refs =>
     Behaviors.receiveMessagePartial { case GetActorTree(reply) =>
-      reply ! refs
       monitor ! Done
       Behaviors.same
     }
@@ -671,7 +670,7 @@ final class ActorEventsMonitorActorTest
     }
   }
 
-  it should "not product any metrics until actroTreeService is availabe" in {
+  it should "not produce any metrics until actorTreeService is available" in {
     val refs         = actorConfiguration(spawnTree(3), ActorConfiguration.instanceConfig)
     val ackProbe     = TestProbe[Done]
     val actorService = system.systemActorOf(countingRefsActorServiceTree(ackProbe.ref)(refs), createUniqueId)
@@ -679,7 +678,7 @@ final class ActorEventsMonitorActorTest
     testCaseWithSetupAndContext(
       _.copy(actorMetricReader = _ => Some(ConstActorMetrics), actorTreeService = actorService)
     ) { implicit setup => implicit context =>
-      collectActorMetrics()
+      collectActorMetrics(ackProbe)
       ackProbe.receiveMessage()
       runUpdaters()
       monitor.sentMessagesProbe.expectNoMessage()
@@ -732,29 +731,6 @@ final class ActorEventsMonitorActorTest
 
     }
   }
-
-//  testCase { implicit context =>
-//    eventually {
-//      timestampFactory.count() should be(1L)
-//    }
-//    monitor.mailboxSizeProbe.receiveMessage()
-//    monitor.mailboxTimeAvgProbe.receiveMessage()
-//    monitor.mailboxTimeMinProbe.receiveMessage()
-//    monitor.mailboxTimeMaxProbe.receiveMessage()
-//    monitor.mailboxTimeSumProbe.receiveMessage()
-//    monitor.stashSizeProbe.receiveMessage()
-//    monitor.receivedMessagesProbe.receiveMessage()
-//    monitor.processedMessagesProbe.receiveMessage()
-//    monitor.failedMessagesProbe.receiveMessage()
-//    monitor.processingTimeAvgProbe.receiveMessage()
-//    monitor.processingTimeMinProbe.receiveMessage()
-//    monitor.processingTimeMaxProbe.receiveMessage()
-//    monitor.processingTimeSumProbe.receiveMessage()
-//    monitor.sentMessagesProbe.receiveMessage()
-//    monitor.droppedMessagesProbe.receiveMessage()
-//    timestampFactory.count() should be >= (2) // this could happen more than once
-//  }
-
 }
 
 object ActorEventsMonitorActorTest {

--- a/extension/src/test/scala/io/scalac/mesmer/extension/ActorEventsMonitorActorTest.scala
+++ b/extension/src/test/scala/io/scalac/mesmer/extension/ActorEventsMonitorActorTest.scala
@@ -1,23 +1,26 @@
 package io.scalac.mesmer.extension
 
+import akka.Done
 import akka.actor.PoisonPill
 import akka.actor.testkit.typed.javadsl.FishingOutcomes
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import akka.actor.testkit.typed.scaladsl.TestProbe
 import akka.actor.typed._
+import akka.actor.typed.scaladsl.AskPattern._
 import akka.actor.typed.scaladsl.Behaviors
 import akka.actor.typed.scaladsl.StashBuffer
 import akka.actor.typed.scaladsl.adapter._
 import akka.util.Timeout
-import akka.{ actor => classic }
+import akka.{actor => classic}
 import org.scalatest.LoneElement
+import org.scalatest.OptionValues
 import org.scalatest.TestSuite
 import org.scalatest.concurrent.PatienceConfiguration
 import org.scalatest.concurrent.ScaledTimeSpans
 
+import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.util.Random
-import scala.util.control.NoStackTrace
 
 import io.scalac.mesmer.core.model._
 import io.scalac.mesmer.core.util.ActorPathOps
@@ -26,7 +29,7 @@ import io.scalac.mesmer.core.util.ReceptionistOps
 import io.scalac.mesmer.core.util.TestCase._
 import io.scalac.mesmer.core.util.TestConfig
 import io.scalac.mesmer.core.util.TestOps
-import io.scalac.mesmer.core.util.probe.ObserverCollector.ScheduledCollectorImpl
+import io.scalac.mesmer.core.util.probe.ObserverCollector.ManualCollectorImpl
 import io.scalac.mesmer.extension.ActorEventsMonitorActor._
 import io.scalac.mesmer.extension.actor.ActorMetrics
 import io.scalac.mesmer.extension.actor.MutableActorMetricStorageFactory
@@ -35,6 +38,7 @@ import io.scalac.mesmer.extension.service.ActorTreeService
 import io.scalac.mesmer.extension.service.ActorTreeService.Command.GetActorTree
 import io.scalac.mesmer.extension.service.ActorTreeService.Command.GetActors
 import io.scalac.mesmer.extension.util.Tree._
+import io.scalac.mesmer.extension.util.TreeF
 import io.scalac.mesmer.extension.util.probe.ActorMonitorTestProbe
 import io.scalac.mesmer.extension.util.probe.BoundTestProbe.CounterCommand
 import io.scalac.mesmer.extension.util.probe.BoundTestProbe.Inc
@@ -54,7 +58,7 @@ import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
 
 //TODO simplify
-class ActorEventsMonitorActorTest
+final class ActorEventsMonitorActorTest
     extends ScalaTestWithActorTestKit(TestConfig.localActorProvider)
     with AnyFlatSpecLike
     with Matchers
@@ -65,48 +69,59 @@ class ActorEventsMonitorActorTest
     with LoneElement
     with TestOps
     with ReceptionistOps
+    with OptionValues
     with ActorEventMonitorActorTestConfig {
+
   import ActorEventsMonitorActorTest._
+
+  /**
+   * process needed here:
+   * - prepare actor refs -
+   * - set up actor from context and monitor
+   * --
+   */
 
   protected type Setup = ActorEventSetup
   type Monitor         = ActorMonitorTestProbe
   type Context         = TestContext
   final val ActorsPerCase = 10
 
-  private val FailingReaderFactory: MetricsContext => ActorMetricsReader = _ => {
-    _ => throw new RuntimeException("Planned failure") with NoStackTrace
-  }
+  val CheckInterval: FiniteDuration = scaled(100.millis)
 
-  private val FakeReaderFactory: MetricsContext => ActorMetricsReader = metrics => {
-    _ => {
-      import metrics._
-      Some(
-        ActorMetrics(
-          mailboxSize = Some(fakeMailboxSize),
-          mailboxTime = Some(fakeMailboxTime),
-          receivedMessages = Some(fakeReceivedMessages),
-          unhandledMessages = Some(fakeUnhandledMessages),
-          failedMessages = Some(fakeFailedMessages),
-          processingTime = Some(fakeProcessingTimes),
-          sentMessages = Some(fakeSentMessages),
-          stashSize = Some(fakeStashedMessages),
-          droppedMessages = Some(fakeDroppedMessages)
-        )
-      )
+  private def treeDataReader(tree: Tree[(classic.ActorRef, ActorMetrics)]): ActorMetricsReader = ref => {
+    tree.unfix.find(_._1 == ref).map { case (_, data) =>
+      data
     }
   }
 
-  private val constRefsActorServiceTree
-    : (ActorRef[CounterCommand], Tree[classic.ActorRef]) => Behavior[ActorTreeService.Command] = (monitor, refs) =>
-    Behaviors.receiveMessage {
-      case GetActorTree(reply) =>
-        monitor ! Inc(1L)
+  private def actorDataReader(actorRef: ActorRef[ReaderCommand])(implicit timeout: Timeout): ActorMetricsReader =
+    classicRef => {
+      Await.result(actorRef.ask[Option[ActorMetrics]](replyTo => GetOne(classicRef, replyTo)), Duration.Inf)
+    }
 
-        reply ! refs.unfix.mapValues(ref => ActorRefDetails(ref, Set(Tag.all), ActorConfiguration.instanceConfig))
+  private def randomActorMetrics(): ActorMetrics = ActorMetrics(
+    Some(Random.nextLong(100)),
+    Some(randomAggMetric()),
+    Some(Random.nextLong(100)),
+    Some(Random.nextLong(100)),
+    Some(Random.nextLong(100)),
+    Some(randomAggMetric()),
+    Some(Random.nextLong(100)),
+    Some(Random.nextLong(100)),
+    Some(Random.nextLong(100))
+  )
+
+  private val addRandomMetrics: Tree[ActorRefDetails] => Tree[(classic.ActorRef, ActorMetrics)] =
+    _.unfix.mapValues(details => (details.ref, randomActorMetrics))
+
+  private val constRefsActorServiceTree: Tree[ActorRefDetails] => Behavior[ActorTreeService.Command] = refs =>
+    Behaviors.receiveMessagePartial {
+      case GetActorTree(reply) =>
+        reply ! refs
         Behaviors.same
 
       case GetActors(Tag.all, reply) =>
-        reply ! refs.unfix.toVector
+        reply ! refs.unfix.toVector.map(_.ref)
         Behaviors.same
       case GetActors(_, reply) =>
         reply ! Seq.empty
@@ -120,38 +135,78 @@ class ActorEventsMonitorActorTest
       Behaviors.same
     }
 
+  private val ConstActorMetrics: ActorMetrics = ActorMetrics(
+    Some(1),
+    Some(LongValueAggMetric(1, 10, 2, 20, 10)),
+    Some(2),
+    Some(3),
+    Some(4),
+    Some(LongValueAggMetric(10, 100, 20, 200, 10)),
+    Some(5),
+    Some(6),
+    Some(7)
+  )
+
+  private def randomAggMetric() = {
+    val x     = Random.nextLong(1000)
+    val y     = Random.nextLong(1000)
+    val sum   = Random.nextLong(1000)
+    val count = Random.nextInt(100) + 1
+    if (x > y) LongValueAggMetric(y, x, sum / count, sum, count) else LongValueAggMetric(x, y, sum / count, sum, count)
+  }
+
   override implicit val timeout: Timeout = pingOffset
 
   protected def createMonitor(implicit system: ActorSystem[_]): ActorMonitorTestProbe = ActorMonitorTestProbe(
-    new ScheduledCollectorImpl(pingOffset)
+    new ManualCollectorImpl
   )
+
   protected def createContextFromMonitor(monitor: ActorMonitorTestProbe)(implicit
     system: ActorSystem[_]
-  ): Context = TestContext(monitor, TestProbe(), FakeReaderFactory, constRefsActorServiceTree)
+  ): Context = TestContext(
+    monitor,
+    TestProbe()
+  )
 
-  private def spawnTree(count: Int): Tree[classic.ActorRef] = {
+  /**
+   * Spawns 1 level deep tree
+   *
+   * @param nodes
+   * @return
+   */
+  private def spawnTree(nodes: Int): Tree[classic.ActorRef] = {
 
     val spawnRoot  = system.systemActorOf(SpawnProtocol(), createUniqueId)
     val spawnProbe = createTestProbe[ActorRef[_]]()
 
     for {
-      _ <- 0 until count
+      _ <- 0 until nodes
     } spawnRoot ! SpawnProtocol.Spawn(Behaviors.empty, createUniqueId, Props.empty, spawnProbe.ref)
 
-    val children = spawnProbe.receiveMessages(count)
+    val children = spawnProbe.receiveMessages(nodes)
 
     spawnProbe.stop()
 
     tree(spawnRoot.toClassic, children.map(ch => leaf(ch.toClassic)): _*)
   }
 
+  private def rootGrouping(
+    refs: Tree[classic.ActorRef],
+    childrenConfiguration: ActorConfiguration = ActorConfiguration.instanceConfig
+  ) = refs.unfix.foldRight[Tree[ActorRefDetails]] {
+    case TreeF(value, Vector()) => leaf(ActorRefDetails(value, Set.empty, childrenConfiguration))
+    case TreeF(value, children) =>
+      tree(ActorRefDetails(value, Set.empty, ActorConfiguration.groupingConfig), children: _*)
+  }
+
+  private def actorConfiguration(
+    refs: Tree[classic.ActorRef],
+    configuration: ActorConfiguration
+  ) = refs.unfix.foldRight[Tree[ActorRefDetails]] { case TreeF(value, children) =>
+    tree(ActorRefDetails(value, Set.empty, configuration), children: _*)
+  }
+
   protected def setUp(c: Context): Setup = {
-
-    val testActors = spawnTree(5)
-
-    val treeServiceBehavior = c.actorTreeServiceBehaviorFactory(c.actorTreeServiceProbe.ref, testActors)
-
-    val treeService = system.systemActorOf(treeServiceBehavior, createUniqueId)
 
     val sut = system.systemActorOf(
       Behaviors
@@ -165,8 +220,8 @@ class ActorEventsMonitorActorTest
                 pingOffset,
                 new MutableActorMetricStorageFactory,
                 scheduler,
-                c.TestActorMetricsReader
-              ).start(treeService)
+                c.actorMetricReader
+              ).start(c.actorTreeService, loop = false) // false is important here!
             }
           }
         )
@@ -174,253 +229,428 @@ class ActorEventsMonitorActorTest
       createUniqueId
     )
 
-    ActorEventSetup(testActors.unfix.toVector, treeService, sut)
+    ActorEventSetup(c.actorTreeService, sut)
   }
 
   protected def tearDown(setup: Setup): Unit =
     setup.allRefs.foreach(_.unsafeUpcast[Any] ! PoisonPill)
 
-  private def TakeLabel(implicit setup: Setup): Labels = {
-    val ref = Random.shuffle(refs).head
-    Labels(ActorPathOps.getPathString(ref))
+  //  private def TakeLabel(implicit setup: Setup): Labels = {
+  //    val ref = Random.shuffle(refs).head
+  //    Labels(ActorPathOps.getPathString(ref))
+  //  }
+
+  def refs(implicit setup: Setup): Seq[classic.ActorRef] = Seq.empty
+
+  def collectData(probe: TestProbe[Done])(implicit setup: Setup): Unit = {
+    setup.sut ! StartActorsMeasurement(Some(probe.ref))
+    probe.receiveMessage()
   }
 
-  def refs(implicit setup: Setup): Seq[classic.ActorRef] = setup.refs
+  //  def metrics(implicit context: Context): MetricsContext = context.metrics
 
-  def sut(implicit setup: Setup): ActorRef[ActorEventsMonitorActor.Command] = setup.sut
+  def collectAll()(implicit context: Context): Unit = context.monitor.collector.collectAll()
 
-  def metrics(implicit context: Context): MetricsContext = context.metrics
+  //  def extractMetric[M <: MetricsContext](check: M => Long)(implicit context: TestContext[M]): Long = check(
+  //    context.metrics
+  //  )
 
-  "ActorEventsMonitor" should "record mailbox size" in testCaseSetupContext { implicit setup => implicit context =>
-    shouldObserveSumWithChange(monitor.mailboxSizeProbe, TakeLabel, _.fakeMailboxSize, _.fakeMailboxSize += 1)
-  }
+  private def waitForObservation(
+    probe: ActorMonitorTestProbe => TestProbe[MetricObserverCommand[Labels]],
+    labels: Labels
+  )(implicit
+    context: Context
+  ) =
+    eventually {
+      collectAll()
+      probe(monitor)
+        .fishForMessage(CheckInterval) {
+          case MetricObserved(_, `labels`) => FishingOutcomes.complete()
+          case _                           => FishingOutcomes.continueAndIgnore()
+        }
+        .loneElement
+    }
 
-  it should "record stash size" in testCaseSetupContext { implicit setup => implicit context =>
-    shouldObserveSumWithChange(monitor.stashSizeProbe, TakeLabel, _.fakeStashedMessages, _.fakeStashedMessages += 10)
-  }
+  /**
+   * Waits for n messages and ensure that no more messages were to delivered
+   *
+   * @param n     amount of messages to wait for
+   * @param probe on which probe operation should be executed
+   * @param context
+   * @return
+   */
+  private def waitForN(n: Int, probe: ActorMonitorTestProbe => TestProbe[MetricObserverCommand[Labels]])(implicit
+    context: Context
+  ) =
+    eventually {
+      collectAll()
+      val chosenProbe = probe(monitor)
+      val messages = chosenProbe
+        .receiveMessages(n, CheckInterval)
+      chosenProbe.expectNoMessage()
+      messages
+    }
 
-  it should "record avg mailbox time" in testCaseSetupContext { implicit setup => implicit context =>
-    shouldObserveLastWithChange(
-      monitor.mailboxTimeAvgProbe,
-      TakeLabel,
-      _.fakeMailboxTime.avg,
-      MailboxTimeModify(incAverage)
-    )
-  }
+  private def rootLabels(tree: Tree[ActorRefDetails]): Labels =
+    Labels(ActorPathOps.getPathString(tree.unfix.value.ref))
 
-  it should "record min mailbox time" in testCaseSetupContext { implicit setup => implicit context =>
-    shouldObserveLastWithChange(
-      monitor.mailboxTimeMinProbe,
-      TakeLabel,
-      _.fakeMailboxTime.min,
-      MailboxTimeModify(incMin)
-    )
-  }
+  private def nonRootLabels(tree: Tree[ActorRefDetails]): Option[Labels] =
+    tree.unfix.foldRight[Option[Labels]] {
+      case TreeF(value, Vector()) =>
+        Some(Labels(ActorPathOps.getPathString(value.ref)))
+      case TreeF(_, children) => Random.shuffle(children.flatten).headOption
+    }
 
-  it should "record max mailbox time" in testCaseSetupContext { implicit setup => implicit context =>
-    shouldObserveLastWithChange(
-      monitor.mailboxTimeMaxProbe,
-      TakeLabel,
-      _.fakeMailboxTime.max,
-      MailboxTimeModify(incMax)
-    )
-  }
+  behavior of "ActorEventsMonitor"
 
-  it should "record sum mailbox time" in testCaseSetupContext { implicit setup => implicit context =>
-    shouldObserveSumWithChange(
-      monitor.mailboxTimeSumProbe,
-      TakeLabel,
-      _.fakeMailboxTime.sum,
-      MailboxTimeModify(incSum)
-    )
-  }
-
-  it should "record received messages" in testCaseSetupContext { implicit setup => implicit context =>
-    shouldObserveSumWithChange(
-      monitor.receivedMessagesProbe,
-      TakeLabel,
-      _.fakeReceivedMessages,
-      _.fakeReceivedMessages += 1
-    )
-  }
-
-  it should "record processed messages" in testCaseSetupContext { implicit setup => implicit context =>
-    shouldObserveSumWithChange(
-      monitor.processedMessagesProbe,
-      TakeLabel,
-      _.fakeProcessedMessages,
-      _.fakeProcessedMessages += 1
-    )
-  }
-
-  it should "record failed messages" in testCaseSetupContext { implicit setup => implicit context =>
-    shouldObserveSumWithChange(
-      monitor.failedMessagesProbe,
-      TakeLabel,
-      _.fakeFailedMessages,
-      _.fakeFailedMessages += 1
-    )
-  }
-
-  it should "record avg processing time" in testCaseSetupContext { implicit setup => implicit context =>
-    shouldObserveLastWithChange(
-      monitor.processingTimeAvgProbe,
-      TakeLabel,
-      _.fakeProcessingTimes.avg,
-      ProcessingTimeModify(incAverage)
-    )
-  }
-
-  it should "record min processing time" in testCaseSetupContext { implicit setup => implicit context =>
-    shouldObserveLastWithChange(
-      monitor.processingTimeMinProbe,
-      TakeLabel,
-      _.fakeProcessingTimes.min,
-      ProcessingTimeModify(incMin)
-    )
-  }
-
-  it should "record max processing time" in testCaseSetupContext { implicit setup => implicit context =>
-    shouldObserveLastWithChange(
-      monitor.processingTimeMaxProbe,
-      TakeLabel,
-      _.fakeProcessingTimes.max,
-      ProcessingTimeModify(incMax)
-    )
-  }
-
-  it should "record sum processing time" in testCaseSetupContext { implicit setup => implicit context =>
-    shouldObserveSumWithChange(
-      monitor.processingTimeSumProbe,
-      TakeLabel,
-      _.fakeProcessingTimes.sum,
-      ProcessingTimeModify(incSum)
-    )
-  }
-
-  it should "record the sent messages" in testCaseSetupContext { implicit setup => implicit context =>
-    shouldObserveSumWithChange(monitor.sentMessagesProbe, TakeLabel, _.fakeSentMessages, _.fakeSentMessages += 1)
-  }
-
-  it should "record the dropped messages" in testCaseSetupContext { implicit setup => implicit context =>
-    shouldObserveSumWithChange(
-      monitor.droppedMessagesProbe,
-      TakeLabel,
-      _.fakeDroppedMessages,
-      _.fakeDroppedMessages += 1
-    )
-  }
-
-  it should "unbind monitors on restart" in testCaseWith(_.copy(metricReaderFactory = FailingReaderFactory)) {
-    implicit context =>
-      eventually {
-        monitor.unbinds should be(1)
-        monitor.binds should be(2)
+  private def expect(
+    selectProbe: ActorMonitorTestProbe => TestProbe[MetricObserverCommand[Labels]],
+    labels: Labels,
+    value: Long
+  )(implicit context: Context): Unit =
+    selectProbe(context.monitor)
+      .fishForMessage(pingOffset) {
+        case MetricObserved(_, `labels`) => FishingOutcomes.complete()
+        case _                           => FishingOutcomes.continueAndIgnore()
       }
-  }
+      .loneElement should be(MetricObserved(value, labels))
 
-  it should "not product any metrics until actroTreeService is availabe" in testCaseWith(
-    _.copy(actorTreeServiceBehaviorFactory = noReplyActorServiceTree)
-  ) { implicit context =>
-    context.actorTreeServiceProbe.expectMessage(Inc(1L))
-    monitor.sentMessagesProbe.expectNoMessage()
-  }
+  /**
+   * Checks aggregation when there were several metrics collection messages but no export in the meantime
+   */
+  private def collectMany[T](
+    selectProbe: ActorMonitorTestProbe => TestProbe[MetricObserverCommand[Labels]],
+    extract: ActorMetrics => T,
+    name: String,
+    combine: (T, T) => T,
+    extractLong: T => Long
+  )(metrics: Seq[ActorMetrics]) =
+    it should s"record ${name} after many transitions" in {
 
-  it should "retry to get actor refs" in testCaseWith(
-    _.copy(actorTreeServiceBehaviorFactory = noReplyActorServiceTree)
-  ) { implicit context =>
-    context.actorTreeServiceProbe.expectMessage(Inc(1L))
-    context.actorTreeServiceProbe.expectMessage(Inc(1L))
-    context.actorTreeServiceProbe.expectMessage(Inc(1L))
-  }
+      val refs         = actorConfiguration(spawnTree(3), ActorConfiguration.instanceConfig)
+      val actorService = system.systemActorOf(constRefsActorServiceTree(refs), createUniqueId)
+      val labels       = Labels(ActorPathOps.getPathString(refs.unfix.value.ref))
 
-  private val incAverage: LongValueAggMetric => LongValueAggMetric = agg => agg.copy(avg = agg.avg + 1)
-  private val incMax: LongValueAggMetric => LongValueAggMetric     = agg => agg.copy(max = agg.max + 1)
-  private val incSum: LongValueAggMetric => LongValueAggMetric     = agg => agg.copy(sum = agg.sum + 1)
-  private val incMin: LongValueAggMetric => LongValueAggMetric     = agg => agg.copy(min = agg.min + 1)
+      val Seq(firstMetrics, metricsTransitions @ _*) = metrics
+      val refsWithMetrics = refs.unfix.mapValues { details =>
+        details.ref -> firstMetrics
+      }
+      val metricsService = system.systemActorOf(readerBehavior(refsWithMetrics), createUniqueId)
 
-  private val ProcessingTimeModify = lens(m => agg => m.fakeProcessingTimes = agg, _.fakeProcessingTimes) _
-  private val MailboxTimeModify    = lens(m => agg => m.fakeMailboxTime = agg, _.fakeMailboxTime) _
+      val expectedValue = extractLong(metrics.map(extract).reduce(combine))
 
-  private def lens(
-    setter: MetricsContext => LongValueAggMetric => Unit,
-    getter: MetricsContext => LongValueAggMetric
-  )(map: LongValueAggMetric => LongValueAggMetric): MetricsContext => Unit = metrics => {
-    setter(metrics)(map(getter(metrics)))
-  }
+      testCaseWithSetupAndContext { ctx =>
+        ctx.copy(actorTreeService = actorService, actorMetricReader = actorDataReader(metricsService))
+      } { implicit setup => implicit context =>
+        val ackProbe = TestProbe[Done]
 
-  def shouldObserve(probe: TestProbe[MetricObserverCommand[Labels]], labels: Labels, metric: Long): Unit =
-    probe
-      .fishForMessage(reasonableTime) {
-        case MetricObserved(`metric`, `labels`) => FishingOutcomes.complete()
-        case MetricObserved(_, _) =>
-          FishingOutcomes.continueAndIgnore()
+        collectData(ackProbe)
+
+        metricsTransitions.foreach { nextMetrics =>
+          metricsService ! ForAll(nextMetrics, ackProbe.ref)
+          ackProbe.receiveMessage()
+          collectData(ackProbe)
+        }
+        collectAll()
+
+        expect(selectProbe, labels, expectedValue)
+      }
+    }
+
+  private def collect[T](
+    selectProbe: ActorMonitorTestProbe => TestProbe[MetricObserverCommand[Labels]],
+    extract: ActorMetrics => T,
+    name: String,
+    combine: (T, T) => T,
+    extractLong: T => Long
+  ): Unit = {
+
+    it should s"add up ${name} for consecutive collections" in {
+
+      val refs         = actorConfiguration(spawnTree(3), ActorConfiguration.instanceConfig)
+      val actorService = system.systemActorOf(constRefsActorServiceTree(refs), createUniqueId)
+      val labels       = Labels(ActorPathOps.getPathString(refs.unfix.value.ref))
+
+      val refsWithMetrics = refs.unfix.mapValues { details =>
+        details.ref -> ConstActorMetrics
       }
 
-  def shouldObserveLastWithChange(
-    probe: TestProbe[MetricObserverCommand[Labels]],
-    labels: Labels,
-    metric: MetricsContext => Long,
-    change: MetricsContext => Unit
-  )(implicit c: Context): Unit = {
-    shouldObserve(probe, labels, metric(metrics))
-    change(metrics)
-    shouldObserve(probe, labels, metric(metrics))
+      testCaseWithSetupAndContext { ctx =>
+        ctx.copy(actorTreeService = actorService, actorMetricReader = treeDataReader(refsWithMetrics))
+      } { implicit setup => implicit context =>
+        val ackProbe = TestProbe[Done]
+
+        collectData(ackProbe)
+        collectData(ackProbe)
+        collectAll()
+
+        val extracted     = extract(ConstActorMetrics)
+        val expectedValue = extractLong(combine(extracted, extracted))
+
+        expect(selectProbe, labels, expectedValue)
+      }
+    }
+
+    it should s"record ${name}" in {
+
+      val refs         = actorConfiguration(spawnTree(3), ActorConfiguration.instanceConfig)
+      val actorService = system.systemActorOf(constRefsActorServiceTree(refs), createUniqueId)
+      val labels       = Labels(ActorPathOps.getPathString(refs.unfix.value.ref))
+
+      val refsWithMetrics = refs.unfix.mapValues { details =>
+        details.ref -> ConstActorMetrics
+      }
+
+      testCaseWithSetupAndContext { ctx =>
+        ctx.copy(actorTreeService = actorService, actorMetricReader = treeDataReader(refsWithMetrics))
+      } { implicit setup => implicit context =>
+        val ackProbe = TestProbe[Done]
+
+        collectData(ackProbe)
+        collectAll()
+
+        expect(selectProbe, labels, extractLong(extract(ConstActorMetrics)))
+
+      }
+    }
   }
 
-  def shouldObserveSumWithChange(
-    probe: TestProbe[MetricObserverCommand[Labels]],
-    labels: Labels,
-    metric: MetricsContext => Long,
-    change: MetricsContext => Unit
-  )(implicit c: Context): Unit = {
-    val first = metric(metrics)
-    shouldObserve(probe, labels, first)
-    change(metrics)
-    shouldObserve(probe, labels, first + metric(metrics))
+  private def reportingAggregation[T](
+    selectProbe: ActorMonitorTestProbe => TestProbe[MetricObserverCommand[Labels]],
+    extract: ActorMetrics => T,
+    name: String,
+    combine: (T, T) => T,
+    extractLong: T => Long
+  )(addMetrics: Tree[ActorRefDetails] => Tree[(classic.ActorRef, ActorMetrics)]): Unit = {
+
+    it should s"aggregate ${name} in root node when child have instance config" in {
+      val refs = rootGrouping(spawnTree(3), ActorConfiguration.instanceConfig)
+
+      val actorService = system.systemActorOf(constRefsActorServiceTree(refs), createUniqueId)
+      val labels       = rootLabels(refs)
+
+      val refsWithMetrics = addMetrics(refs)
+
+      val expectedValue = extractLong(refsWithMetrics.unfix.foldRight[T] { case TreeF((_, metrics), children) =>
+        children.fold(extract(metrics))(combine)
+      })
+
+      testCaseWithSetupAndContext { ctx =>
+        ctx.copy(actorTreeService = actorService, actorMetricReader = treeDataReader(refsWithMetrics))
+      } { implicit setup => implicit context =>
+        val ackProbe = TestProbe[Done]
+
+        collectData(ackProbe)
+        collectAll()
+
+        expect(selectProbe, labels, expectedValue)
+      }
+    }
+
+    it should s"aggregate ${name} in root node when child have disabled config" in {
+      val refs         = rootGrouping(spawnTree(3), ActorConfiguration.disabledConfig)
+      val actorService = system.systemActorOf(constRefsActorServiceTree(refs), createUniqueId)
+      val labels       = rootLabels(refs)
+
+      val refsWithMetrics = addMetrics(refs)
+      val expectedValue = extractLong(refsWithMetrics.unfix.foldRight[T] { case TreeF((_, metrics), children) =>
+        children.fold(extract(metrics))(combine)
+      })
+
+      testCaseWithSetupAndContext { ctx =>
+        ctx.copy(actorTreeService = actorService, actorMetricReader = treeDataReader(refsWithMetrics))
+      } { implicit setup => implicit context =>
+        val ackProbe = TestProbe[Done]
+
+        collectData(ackProbe)
+        collectAll()
+
+        expect(selectProbe, labels, expectedValue)
+
+      }
+    }
+
+    it should s"publish ${name} for non-root node when child have instance config" in {
+      val refs         = rootGrouping(spawnTree(3), ActorConfiguration.instanceConfig)
+      val actorService = system.systemActorOf(constRefsActorServiceTree(refs), createUniqueId)
+      val labels       = nonRootLabels(refs).value
+
+      val refsWithMetrics = addMetrics(refs)
+
+      val expectedValue = extractLong(extract(refsWithMetrics.unfix.find { case (ref, _) =>
+        ref.path.toStringWithoutAddress == labels.actorPath
+      }.map(_._2).value))
+
+      testCaseWithSetupAndContext { ctx =>
+        ctx.copy(actorTreeService = actorService, actorMetricReader = treeDataReader(refsWithMetrics))
+      } { implicit setup => implicit context =>
+        val ackProbe = TestProbe[Done]
+
+        collectData(ackProbe)
+        collectAll()
+
+        expect(selectProbe, labels, expectedValue)
+      }
+    }
+
+    it should s"not publish ${name} for non-root node when child have disabled config" in {
+      val refs         = rootGrouping(spawnTree(3), ActorConfiguration.disabledConfig)
+      val actorService = system.systemActorOf(constRefsActorServiceTree(refs), createUniqueId)
+      val labels       = rootLabels(refs)
+
+      val refsWithMetrics = addMetrics(refs)
+
+      testCaseWithSetupAndContext { ctx =>
+        ctx.copy(actorTreeService = actorService, actorMetricReader = treeDataReader(refsWithMetrics))
+      } { implicit setup => implicit context =>
+        val ackProbe = TestProbe[Done]
+
+        collectData(ackProbe)
+        collectAll()
+
+        val probe = selectProbe(context.monitor)
+
+        inside(probe.receiveMessage) { case MetricObserved(_, l) =>
+          l should be(labels)
+        }
+        probe.expectNoMessage()
+      }
+    }
   }
+
+  def allBehaviorsLong(
+    selectProbe: ActorMonitorTestProbe => TestProbe[MetricObserverCommand[Labels]],
+    extract: ActorMetrics => Option[Long],
+    name: String
+  ): Unit = {
+    collect[Option[Long]](selectProbe, extract, name, combine, _.get)
+    collectMany[Option[Long]](selectProbe, extract, name, combine, _.get)(Seq.fill(10)(randomActorMetrics()))
+    (reportingAggregation[Option[Long]](
+      selectProbe,
+      extract,
+      name,
+      combine,
+      _.get
+    )(addRandomMetrics))
+
+  }
+
+  def allBehaviorsAgg(
+    probeAvg: ActorMonitorTestProbe => TestProbe[MetricObserverCommand[Labels]],
+    probeMin: ActorMonitorTestProbe => TestProbe[MetricObserverCommand[Labels]],
+    probeMax: ActorMonitorTestProbe => TestProbe[MetricObserverCommand[Labels]],
+    probeSum: ActorMonitorTestProbe => TestProbe[MetricObserverCommand[Labels]],
+    extract: ActorMetrics => Option[LongValueAggMetric],
+    name: String
+  ): Unit = {
+    val args
+      : List[(String, LongValueAggMetric => Long, ActorMonitorTestProbe => TestProbe[MetricObserverCommand[Labels]])] =
+      List(("avg", _.avg, probeAvg), ("min", _.min, probeMin), ("max", _.max, probeMax), ("sum", _.sum, probeSum))
+    for {
+      (suffix, mapping, probe) <- args
+    } {
+      collect[Option[LongValueAggMetric]](probe, extract, s"$name $suffix", combineAgg, _.map(mapping).get)
+      reportingAggregation[Option[LongValueAggMetric]](
+        probe,
+        extract,
+        s"$name $suffix",
+        combineAgg,
+        _.map(mapping).get
+      )((addRandomMetrics))
+      collectMany[Option[LongValueAggMetric]](probe, extract, s"$name $suffix", combineAgg, _.map(mapping).get)(
+        Seq.fill(10)(randomActorMetrics())
+      )
+
+    }
+
+  }
+
+  private val combine: (Option[Long], Option[Long]) => Option[Long] = (optX, optY) => {
+    (for {
+      x <- optX
+      y <- optY
+    } yield (x + y))
+  }
+
+  private val combineAgg: (Option[LongValueAggMetric], Option[LongValueAggMetric]) => Option[LongValueAggMetric] =
+    (optX, optY) => {
+      (for {
+        x <- optX
+        y <- optY
+      } yield x.combine(y))
+    }
+
+  it should behave like allBehaviorsLong(_.mailboxSizeProbe, _.mailboxSize, "mailbox size")
+  it should behave like allBehaviorsLong(_.receivedMessagesProbe, _.receivedMessages, "received messages")
+  it should behave like allBehaviorsLong(_.failedMessagesProbe, _.failedMessages, "failed messages")
+  it should behave like allBehaviorsLong(_.sentMessagesProbe, _.sentMessages, "sent messages")
+  it should behave like allBehaviorsLong(_.stashSizeProbe, _.stashSize, "stash messages")
+  it should behave like allBehaviorsLong(_.droppedMessagesProbe, _.droppedMessages, "dropped messages")
+  it should behave like allBehaviorsLong(_.processedMessagesProbe, _.processedMessages, "processed messages")
+
+  it should behave like allBehaviorsAgg(
+    _.mailboxTimeAvgProbe,
+    _.mailboxTimeMinProbe,
+    _.mailboxTimeMaxProbe,
+    _.mailboxTimeSumProbe,
+    _.mailboxTime,
+    "mailbox time"
+  )
+
+  it should behave like allBehaviorsAgg(
+    _.processingTimeAvgProbe,
+    _.processingTimeMinProbe,
+    _.processingTimeMaxProbe,
+    _.processingTimeSumProbe,
+    _.processingTime,
+    "processing time"
+  )
+
+//  it should "unbind monitors on restart" in testCaseWith(_.copy(metricReaderFactory = FailingReaderFactory)) {
+//    implicit context =>
+//      eventually {
+//        monitor.unbinds should be(1)
+//        monitor.binds should be(2)
+//      }
+//  }
+//
+//  it should "not product any metrics until actroTreeService is availabe" in testCaseWith(
+////    _.copy(actorTreeServiceBehaviorFactory = noReplyActorServiceTree)
+//    identity
+//  ) { implicit context =>
+//    context.actorTreeServiceProbe.expectMessage(Inc(1L))
+//    monitor.sentMessagesProbe.expectNoMessage()
+//  }
+//
+//  it should "retry to get actor refs" in testCaseWith(
+//    //    _.copy(actorTreeServiceBehaviorFactory = noReplyActorServiceTree)
+//    identity
+//  ) { implicit context =>
+//    context.actorTreeServiceProbe.expectMessage(Inc(1L))
+//    context.actorTreeServiceProbe.expectMessage(Inc(1L))
+//    context.actorTreeServiceProbe.expectMessage(Inc(1L))
+//  }
 }
 
 object ActorEventsMonitorActorTest {
 
   final case class ActorEventSetup(
-    refs: Seq[classic.ActorRef],
     service: ActorRef[ActorTreeService.Command],
     sut: ActorRef[ActorEventsMonitorActor.Command]
   ) {
-    def allRefs: Seq[classic.ActorRef] = refs :+ service.toClassic :+ sut.toClassic
+    def allRefs: Seq[classic.ActorRef] = Seq(service.toClassic, sut.toClassic)
   }
 
-  final class MetricsContext() {
-    @volatile var fakeMailboxSize       = 10
-    @volatile var fakeReceivedMessages  = 12
-    @volatile var fakeProcessedMessages = 10
-    @volatile var fakeFailedMessages    = 2
-    @volatile var fakeSentMessages      = 10
-    @volatile var fakeStashedMessages   = 19
-    @volatile var fakeDroppedMessages   = 0
-
-    @volatile var fakeMailboxTime: LongValueAggMetric     = LongValueAggMetric(1, 2, 1, 4, 3)
-    @volatile var fakeProcessingTimes: LongValueAggMetric = LongValueAggMetric(1, 2, 1, 4, 3)
-
-    def fakeUnhandledMessages: Long = fakeReceivedMessages - fakeProcessedMessages
-  }
+  private val NoMetricsReader: ActorMetricsReader = _ => None
 
   final case class TestContext(
     monitor: ActorMonitorTestProbe,
     actorTreeServiceProbe: TestProbe[CounterCommand],
-    metricReaderFactory: MetricsContext => ActorMetricsReader,
-    actorTreeServiceBehaviorFactory: (
-      ActorRef[CounterCommand],
-      Tree[classic.ActorRef]
-    ) => Behavior[ActorTreeService.Command]
+    actorMetricReader: ActorMetricsReader = NoMetricsReader,
+    actorTreeService: ActorRef[ActorTreeService.Command] = classic.ActorRef.noSender.toTyped[ActorTreeService.Command]
   )(implicit
     val system: ActorSystem[_]
   ) extends MonitorTestCaseContext[ActorMonitorTestProbe] {
-
-    val metrics = new MetricsContext()
-
-    val TestActorMetricsReader: ActorMetricsReader = metricReaderFactory(metrics)
 
     sealed trait Command
 
@@ -455,5 +685,37 @@ object ActorEventsMonitorActorTest {
 
     }
 
+  }
+
+  sealed trait ReaderCommand
+
+  final case class GetOne(ref: classic.ActorRef, replyTo: ActorRef[Option[ActorMetrics]]) extends ReaderCommand
+
+  final case class ForAll(metrics: ActorMetrics, replyTo: ActorRef[Done]) extends ReaderCommand
+
+  final case class ForOne(ref: classic.ActorRef, metrics: ActorMetrics, replyTo: ActorRef[Done]) extends ReaderCommand
+
+  def readerBehavior(refs: Tree[(classic.ActorRef, ActorMetrics)]): Behavior[ReaderCommand] = Behaviors.receiveMessage {
+    case ForAll(metrics, replyTo) =>
+      val nextRefs = refs.unfix.mapValues { case (ref, _) =>
+        (ref, metrics)
+      }
+      replyTo ! Done
+      readerBehavior(nextRefs)
+
+    case ForOne(targetRef, metrics, replyTo) =>
+      val nextRefs = refs.unfix.mapValues {
+        case (ref, _) if ref == targetRef =>
+          (ref, metrics)
+        case x => x
+      }
+      replyTo ! Done
+      readerBehavior(nextRefs)
+
+    case GetOne(targetRef, replyTo) =>
+      replyTo ! refs.unfix.find { case (ref, _) =>
+        ref == targetRef
+      }.map(_._2)
+      Behaviors.same
   }
 }

--- a/extension/src/test/scala/io/scalac/mesmer/extension/service/ActorTreeServiceTest.scala
+++ b/extension/src/test/scala/io/scalac/mesmer/extension/service/ActorTreeServiceTest.scala
@@ -56,9 +56,7 @@ class ActorTreeServiceTest
 
   protected def createMonitorBehavior(implicit context: Context): Behavior[Command] =
     Behaviors.setup { ctx =>
-      new ActorTreeService(ctx, monitor, ref => context.bindProbe.ref ! ref, context.traverser, instanceActorConfig)(
-        ActorTreeService.partialOrdering
-      )
+      new ActorTreeService(ctx, monitor, ref => context.bindProbe.ref ! ref, context.traverser, instanceActorConfig)
     }
 
   protected def createMonitor(implicit system: ActorSystem[_]): Monitor =

--- a/extension/src/test/scala/io/scalac/mesmer/extension/util/TreeBuilderTest.scala
+++ b/extension/src/test/scala/io/scalac/mesmer/extension/util/TreeBuilderTest.scala
@@ -1,9 +1,12 @@
 package io.scalac.mesmer.extension.util
 
-import io.scalac.mesmer.extension.util.Tree.NonRoot._
-import io.scalac.mesmer.extension.util.Tree.{ NonRoot, Root, TreeOrdering }
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+
+import io.scalac.mesmer.extension.util.Tree.NonRoot
+import io.scalac.mesmer.extension.util.Tree.NonRoot._
+import io.scalac.mesmer.extension.util.Tree.Root
+import io.scalac.mesmer.extension.util.Tree.TreeOrdering
 
 class TreeBuilderTest extends AnyFlatSpec with Matchers {
 
@@ -18,7 +21,7 @@ class TreeBuilderTest extends AnyFlatSpec with Matchers {
     def lteq(x: String, y: String): Boolean = tryCompare(x, y).fold(false)(_ < 0)
   }
 
-  implicit val treeOrdering = TreeOrdering.fromPartialOrdering(stringPartialOrdering)
+  implicit val treeOrdering: TreeOrdering[String] = TreeOrdering.fromPartialOrdering(stringPartialOrdering)
 
   private def builder: Root[String, String] = Tree.builder[String, String].asInstanceOf[Root[String, String]]
 


### PR DESCRIPTION
Changes in PR:
* adds new command to `ActorTreeService` - `TagSubscription` thats allows to subscribe for a specific tag
* all actors that terminate gets assigned tag `terminated` - subscribing to this tag allows to subscribe get information about all actors that terminated.
* `ActorEventMonitorActor` now subscribe to `terminated` tag and accumulate terminated actors metrics until normal collection happens - then accumulated metrics are added to it's ancestor if it set to `grouping`.
* tests for `ActorEventMonitorActor` changed completely - now all collection happen manually thus giving more control over test but making those more verbose