### PR TITLE
Fix akka extension name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ libraryDependencies += "io.scalac" %% "mesmer-akka-extension" % "<version>"
 
 Add this entry to your `application.conf`:
 
-    akka.actor.typed.extensions= ["io.scalac.mesmer.extension.Mesmer"] 
+    akka.actor.typed.extensions= ["io.scalac.mesmer.extension.AkkaMonitoring"] 
 
 ### JVM agent:
 


### PR DESCRIPTION
Mesmer extension was renamed to AkkaMonitoring but the docs was not updated. Fixing.