### PR TITLE
Change collector docker image

### DIFF
--- a/example/docker/docker-compose.yaml
+++ b/example/docker/docker-compose.yaml
@@ -15,7 +15,7 @@ services:
 
   otel-collector:
     container_name: mesmer_example_otel_collector
-    image: otel/opentelemetry-collector-dev:latest
+    image: otel/opentelemetry-collector-contrib-dev:latest
     command: [ "--config=/etc/otel-collector-config.yaml", "" ]
     volumes:
       - ./otel-collector-config.yaml:/etc/otel-collector-config.yaml


### PR DESCRIPTION
We use health check, pprof and, most importantly, prometheus exporter
 in the otel config. These three are in the contrib repository/docker image.

 More: https://opentelemetry.io/docs/concepts/data-collection/#repositories