### PR TITLE
Add otelExtension to all projects configuration (build.sbt)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -39,7 +39,7 @@ lazy val all = (project in file("."))
     name           := "mesmer-all",
     publish / skip := true
   )
-  .aggregate(extension, agent, example, core)
+  .aggregate(extension, agent, otelExtension, example, core)
 
 lazy val core = (project in file("core"))
   .disablePlugins(sbtassembly.AssemblyPlugin)


### PR DESCRIPTION
Closes #335
___

## Summary:

sbt ci-release is run on the top level. Since otelExtension was missing in `all`, It was skipped by the plugin 



